### PR TITLE
Remove override of createJSModules

### DIFF
--- a/android/src/main/java/com/remobile/dialogs/RCTDialogsPackage.java
+++ b/android/src/main/java/com/remobile/dialogs/RCTDialogsPackage.java
@@ -19,11 +19,6 @@ public class RCTDialogsPackage implements ReactPackage {
     }
 
     @Override
-    public List<Class<? extends JavaScriptModule>> createJSModules() {
-        return Collections.emptyList();
-    }
-
-    @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
         return Arrays.<ViewManager>asList();
     }


### PR DESCRIPTION
Since of recently in master the unused createJSModules has been removed and ReactPackage's no longer contain the definition of createJSModules. There for it must be removed in order to not yield a compile error. This is breaking change.

https://github.com/facebook/react-native/commit/ce6fb337a146e6f261f2afb564aa19363774a7a8